### PR TITLE
AB#2360: created a reusable build and test for typescript

### DIFF
--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -13,13 +13,6 @@ jobs:
           node-version: "lts/*"
       - run: yarn install
       - run: yarn build
+      - run: yarn lint
       - run: yarn test:unit
-      - name: "remove dev dependencies"
-        run: yarn install --production
-      - name: "build artifact"
-        run: zip -r build.zip build node_modules
-      - name: "upload artifact to github"
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: build.zip
+      

--- a/.github/workflows/typescript-build-test-and-package.yml
+++ b/.github/workflows/typescript-build-test-and-package.yml
@@ -1,0 +1,25 @@
+name: build-test-and-package
+
+on:
+  workflow_call:
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "lts/*"
+      - run: yarn install
+      - run: yarn build
+      - run: yarn test:unit
+      - name: "remove dev dependencies"
+        run: yarn install --production
+      - name: "build artifact"
+        run: zip -r build.zip build node_modules
+      - name: "upload artifact to github"
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build.zip

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ TODO: decide how to version these. most likely git tags
 ### lambda-deploy
 this just downloads a zip file called "build", which should have a file called "build.zip", which will get pushed to a lambda by name and region.  you have to pass in a github environment name to control how and when a deployment will go out. 
 
-### typescript-build-and-test
-this builds a typescript app up based on a very simple convention.  it runs the following commands on the lts version of node (14.x currently).
+### typescript-build-test-and-package
+this builds a typescript app up based on a very simple convention.  it runs the following commands on the lts version of node. it was formerly the `typescript-build-and-test@v1`.
 ```bash
 yarn install
 yarn build
@@ -23,6 +23,15 @@ yarn test:unit
 yarn install --production
 zip -r build.zip build node_modules
 # uploads build.zip to github artifact as "build"
+```
+
+### typescript-build-and-test
+this builds a typescript app up based on a very simple convention.  it runs the following commands on the lts version of node.
+```bash
+yarn install
+yarn lint
+yarn build
+yarn test:unit
 ```
 
 ### build-and-test-npm-package


### PR DESCRIPTION
# overview

the old "build and test" would package things up in a zip for lambda deployments and other things to use as artifacts.  this is just simply a build and test for typescript.

adjusted the documentation.  i will probably just make a tag `v2` once this is merged.  everything should continue working the same that uses `v1` tags...﻿
