### PR TITLE
Adding npm_token as secret input to typescript workflow

### DIFF
--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -2,6 +2,9 @@ name: build-and-test
 
 on:
   workflow_call:
+    secrets:
+      npm_token:
+        required: false
 
 jobs:
   build_and_test:


### PR DESCRIPTION
# Overview
Some repos have private npm packages that require an .npmrc and NPM_TOKEN in order to install them. This would allow those consumers to use this workflow