### PR TITLE
tryig to make integration tests optionally run

### DIFF
--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -2,6 +2,12 @@ name: build-and-test
 
 on:
   workflow_call:
+    inputs:
+      run-integration-tests:
+        description: "flag to run `yarn test:int` command"
+        default: false
+        required: false
+        type: boolean
     secrets:
       npm-token:
         required: false
@@ -20,4 +26,7 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test:unit
+      - name: integration tests
+        run: yarn test:int
+        if: ${{ inputs.run-integration-tests }}
       


### PR DESCRIPTION
# overview

this allows for running integration tests (which is `yarn test:int` command) by setting a variable to true.  this should not break anyone currently using the modules either since its optional input.

## testing

i ran this in a gh action and it worked