### PR TITLE
chore: updated build, test, and package to be same as build and test script

### DIFF
--- a/.github/workflows/typescript-build-test-and-package.yml
+++ b/.github/workflows/typescript-build-test-and-package.yml
@@ -2,10 +2,21 @@ name: build-test-and-package
 
 on:
   workflow_call:
+    inputs:
+      run-integration-tests:
+        description: "flag to run `yarn test:int` command"
+        default: false
+        required: false
+        type: boolean
+    secrets:
+      npm-token:
+        required: false
 
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.npm-token }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -13,7 +24,11 @@ jobs:
           node-version: "lts/*"
       - run: yarn install
       - run: yarn build
+      - run: yarn lint
       - run: yarn test:unit
+      - name: integration tests
+        run: yarn test:int
+        if: ${{ inputs.run-integration-tests }}
       - name: "remove dev dependencies"
         run: yarn install --production
       - name: "build artifact"


### PR DESCRIPTION
# overview

just making the scripts the same behavior, except this adds packaging at the end...


the diff of the two files `diff typescript-build-and-test.yml typescript-build-test-and-package.yml`

```diff
1c1
< name: build-and-test
---
> name: build-test-and-package
32c32,40
<       
\ No newline at end of file
---
>       - name: "remove dev dependencies"
>         run: yarn install --production
>       - name: "build artifact"
>         run: zip -r build.zip build node_modules
>       - name: "upload artifact to github"
>         uses: actions/upload-artifact@v2
>         with:
>           name: build
>           path: build.zip
```﻿
