### PR TITLE
feat: working-directory input param

### DIFF
--- a/.github/workflows/build-and-test-npm-package.yml
+++ b/.github/workflows/build-and-test-npm-package.yml
@@ -20,7 +20,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.github-token }}
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ inputs.working-directory }} || .
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/build-and-test-npm-package.yml
+++ b/.github/workflows/build-and-test-npm-package.yml
@@ -20,7 +20,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.github-token }}
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory }} || src
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/build-and-test-npm-package.yml
+++ b/.github/workflows/build-and-test-npm-package.yml
@@ -20,7 +20,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.github-token }}
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory }} || ./src
+        working-directory: ${{ inputs.working-directory }} || src
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/build-and-test-npm-package.yml
+++ b/.github/workflows/build-and-test-npm-package.yml
@@ -2,6 +2,10 @@ name: build and test npm package
 
 on:
   workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        required: false
     secrets:
       npm-token:
         required: true
@@ -14,6 +18,9 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.npm-token }}
       GITHUB_TOKEN: ${{ secrets.github-token }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/build-and-test-npm-package.yml
+++ b/.github/workflows/build-and-test-npm-package.yml
@@ -6,6 +6,7 @@ on:
       working-directory:
         type: string
         required: false
+        default: ./
     secrets:
       npm-token:
         required: true

--- a/.github/workflows/build-and-test-npm-package.yml
+++ b/.github/workflows/build-and-test-npm-package.yml
@@ -20,7 +20,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.github-token }}
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory }} || .
+        working-directory: ${{ inputs.working-directory || ./ }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/build-and-test-npm-package.yml
+++ b/.github/workflows/build-and-test-npm-package.yml
@@ -20,7 +20,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.github-token }}
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory || ./ }}
+        working-directory: ${{ inputs.working-directory }} || ./src
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -6,6 +6,10 @@ on:
       image-tag:
         required: true
         type: string
+      working-directory:
+        type: string
+        required: false
+        default: ./
     secrets:
       npm-token:
         required: true
@@ -19,6 +23,9 @@ on:
 jobs:
   build_docker:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -8,6 +8,9 @@ on:
         default: false
         required: false
         type: boolean
+      working-directory:
+        type: string
+        required: false
     secrets:
       npm-token:
         required: false
@@ -17,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_TOKEN: ${{ secrets.npm-token }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -11,6 +11,7 @@ on:
       working-directory:
         type: string
         required: false
+        default: ./
     secrets:
       npm-token:
         required: false


### PR DESCRIPTION
# Overview
This will add a new optional parameter that will allow consumers to run the typescript, npm package, and docker container jobs in a specified directory. If no directory is specified, it will just on the root, as it did previously.

## Ticket
[AB#2741](https://dev.azure.com/revolutionmtg/Revolution%20Mortgage/_workitems/edit/2741)