### PR TITLE
feat: bumping major versions of setupnode and checkout for docker and typescript actions

### DIFF
--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -27,7 +27,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # gain access to aws tools account
       - uses: Fooji/create-aws-profile-action@v1

--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/*"
+          cache: "yarn"
       - run: yarn install
       - run: yarn build
       - run: yarn lint

--- a/.github/workflows/typescript-build-test-and-package.yml
+++ b/.github/workflows/typescript-build-test-and-package.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
+          cache: "yarn"
       - run: yarn install
       - run: yarn build
       - run: yarn lint

--- a/.github/workflows/typescript-build-test-and-package.yml
+++ b/.github/workflows/typescript-build-test-and-package.yml
@@ -18,8 +18,8 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.npm-token }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
       - run: yarn install


### PR DESCRIPTION
# Overview
This makes sure that all jobs in the typescript and docker build actions are running on node 16 and no longer on the deprecated node 12