### PR TITLE
chore: default node version is lts/gallium aka v16.x.x

### DIFF
--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -12,6 +12,10 @@ on:
         type: string
         required: false
         default: ./
+      node-version:
+        type: string
+        required: false
+        default: "lts/gallium"
     secrets:
       npm-token:
         required: false
@@ -25,10 +29,10 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
+          node-version: ${{ inputs.working-directory }}
           cache: "yarn"
       - run: yarn install
       - run: yarn build

--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ inputs.working-directory }}
+          node-version: ${{ inputs.node-version }}
           cache: "yarn"
       - run: yarn install
       - run: yarn build


### PR DESCRIPTION
# overview

a long long time ago i mentioned we should pin this version to the correct lts 16 version as it would probably upgrade by itself.  almost like i envisioned the future itself, now it is running node 18.x.x lts.

this defaults the node version to `lts/gallium` which is the lts of 16.x.x which we use for runtime in docker currently.  you can also override it if we start upgrading, but what is running in docker should also be whats running in github actions.

## testing

i tested this in creditplus repo using the git sha and it worked fine.