### PR TITLE
feat: support non root package.json files

### DIFF
--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -11,7 +11,7 @@ on:
       working-directory:
         type: string
         required: false
-        default: ./
+        default: .
       node-version:
         type: string
         required: false
@@ -34,6 +34,7 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: "yarn"
+          cache-dependency-path: "${{ inputs.working-directory }}/yarn.lock"
       - run: yarn install
       - run: yarn build
       - run: yarn lint


### PR DESCRIPTION
# overview

this adds support for when you are working on a package that uses a sub directory to hold the package files.

## testing
tested on projects using sub directory and projects using root directory and both worked.