### PR TITLE
feat(typescript-build-test-and-package): allow node version to be set

### DIFF
--- a/.github/workflows/typescript-build-test-and-package.yml
+++ b/.github/workflows/typescript-build-test-and-package.yml
@@ -8,6 +8,10 @@ on:
         default: false
         required: false
         type: boolean
+      node-version:
+          type: string
+          required: false
+          default: "lts/gallium"
     secrets:
       npm-token:
         required: false
@@ -21,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
+          node-version: ${{ inputs.node-version }}
           cache: "yarn"
       - run: yarn install
       - run: yarn build


### PR DESCRIPTION
# overview

allowing the node version to be set during the buid, lint, testing, and packaging.

