### PR TITLE
chore: add format command to typecript build scripts

### DIFF
--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -37,6 +37,7 @@ jobs:
           cache-dependency-path: "${{ inputs.working-directory }}/yarn.lock"
       - run: yarn install
       - run: yarn build
+      - run: yarn format
       - run: yarn lint
       - run: yarn test:unit
       - name: integration tests

--- a/.github/workflows/typescript-build-test-and-package.yml
+++ b/.github/workflows/typescript-build-test-and-package.yml
@@ -29,6 +29,7 @@ jobs:
           cache: "yarn"
       - run: yarn install
       - run: yarn build
+      - run: yarn format
       - run: yarn lint
       - run: yarn test:unit
       - name: integration tests


### PR DESCRIPTION
# overview

add `format` command to these two typescript build scripts we share across projects.