### PR TITLE
feat(typescript-build-and-test): support for overriding the test:int command

### DIFF
--- a/.github/workflows/typescript-build-and-test.yml
+++ b/.github/workflows/typescript-build-and-test.yml
@@ -12,6 +12,10 @@ on:
         type: string
         required: false
         default: ./
+      override-integration-test-command:
+        description: "override the default integration test command"
+        required: false
+        type: string
     secrets:
       npm-token:
         required: false
@@ -35,6 +39,6 @@ jobs:
       - run: yarn lint
       - run: yarn test:unit
       - name: integration tests
-        run: yarn test:int
+        run: ${{ inputs.override-integration-test-command || 'yarn test:int' }}
         if: ${{ inputs.run-integration-tests }}
       


### PR DESCRIPTION
# Overview
This adds an optional input to allow an override for the integration test command

## Task
[AB#5361](https://dev.azure.com/revolutionmtg/aee0cc65-3f8d-46ae-9f0c-d18e0eceb58d/_workitems/edit/5361)