### PR TITLE
feat(docker-build-tag-publish): npm token as build secret

### DIFF
--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -64,5 +64,5 @@ jobs:
           # setup target if provided
 
           # build, tag, push
-          docker build --build-arg NPM_TOKEN=${NPM_TOKEN} . -t $tag --target "$TARGET"
+          docker build --secret id=npm-token,env=NPM_TOKEN . -t $tag --target "$TARGET"
           docker push $tag


### PR DESCRIPTION
# Overview
This supports a new feature that builds containers using a build secret for the npm token.

BREAKING CHANGE: this requires the npm token in the `Dockerfile`s to be a build secret and not a build arg, as this is an unsecure place for npm token

## Task
[AB#5372](https://dev.azure.com/revolutionmtg/aee0cc65-3f8d-46ae-9f0c-d18e0eceb58d/_workitems/edit/5372)