### PR TITLE
feat: support buildx + yarn cache

### DIFF
--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -92,8 +92,12 @@ jobs:
             cache_args="--cache-to type=local,dest=/tmp/$IMAGE_TAG-buildx-cache --cache-from type=local,src=/tmp/$IMAGE_TAG-buildx-cache"
           fi
 
+          echo "Building and tagging image with tag: $tag"
+          echo "Cache args: $cache_args"
+          echo "Publish is set to: $PUBLISH"
+          echo "\n\n"
           # build, tag
-          docker buildx build --secret id=npm-token,env=NPM_TOKEN . -t $tag --target "$TARGET" $cache_args
+          docker buildx build --secret id=npm-token,env=NPM_TOKEN -t $tag --target "$TARGET" $cache_args .
 
           # push if publish is true
           if [ "$PUBLISH" = "true" ]; then

--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -93,7 +93,7 @@ jobs:
           fi
 
           # build, tag
-          docker build --secret id=npm-token,env=NPM_TOKEN . -t $tag --target "$TARGET" $cache_args
+          docker buildx build --secret id=npm-token,env=NPM_TOKEN . -t $tag --target "$TARGET" $cache_args
 
           # push if publish is true
           if [ "$PUBLISH" = "true" ]; then

--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -47,7 +47,7 @@ jobs:
         if: ${{ inputs.cache-buildx-yarn }}
         uses: actions/cache@v4
         with:
-          path: /tmp/${{inputs.image-tag}}-buildx-cache
+          path: /tmp/buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -89,7 +89,7 @@ jobs:
           # set cache args if enabled
           cache_args=""
           if [ "$CACHE_BUILDX_YARN" = "true" ]; then
-            cache_args="--cache-to type=local,dest=/tmp/$IMAGE_TAG-buildx-cache --cache-from type=local,src=/tmp/$IMAGE_TAG-buildx-cache"
+            cache_args="--cache-to type=local,dest=/tmp/buildx-cache --cache-from type=local,src=/tmp/buildx-cache"
           fi
 
           echo "Building and tagging image with tag: $tag"

--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -14,6 +14,11 @@ on:
         type: string
         required: false
         default: ""
+      cache-buildx-yarn:
+        description: cache `.yarn/cache` to speed up builds based on yarn.lock.  you have to have the mount=type=cache in your dockerfile for this to work
+        type: boolean
+        required: false
+        default: false
     secrets:
       npm-token:
         required: true
@@ -32,6 +37,17 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: cache buildx
+        if: ${{ inputs.cache-buildx-yarn }}
+        uses: actions/cache@v4
+        with:
+          path: /tmp/${{inputs.image-tag}}-buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       # gain access to aws tools account
       - uses: Fooji/create-aws-profile-action@v1
@@ -55,6 +71,7 @@ jobs:
           REGISTRY_HOSTNAME: ${{ secrets.registry-hostname }}
           IMAGE_TAG: ${{ inputs.image-tag }}
           TARGET: ${{ inputs.image-target }}
+          CACHE_BUILDX_YARN: ${{ inputs.cache-buildx-yarn }}
         run: |
           timestamp=$(date +%s)
           sha=$(git rev-parse --short HEAD)
@@ -63,6 +80,12 @@ jobs:
           tag="$REGISTRY_HOSTNAME/$IMAGE_TAG:$branch-$sha-$timestamp"
           # setup target if provided
 
+          # set cache args if enabled
+          cache_args=""
+          if [ "$CACHE_BUILDX_YARN" = "true" ]; then
+            cache_args="--cache-to type=local,dest=/tmp/$IMAGE_TAG-buildx-cache --cache-from type=local,src=/tmp/$IMAGE_TAG-buildx-cache"
+          fi
+
           # build, tag, push
-          docker build --secret id=npm-token,env=NPM_TOKEN . -t $tag --target "$TARGET"
+          docker build --secret id=npm-token,env=NPM_TOKEN . -t $tag --target "$TARGET" $cache_args
           docker push $tag

--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -19,6 +19,11 @@ on:
         type: boolean
         required: false
         default: false
+      publish:
+        description: 'If true, docker push will be run after build.'
+        type: boolean
+        required: false
+        default: true
     secrets:
       npm-token:
         required: true
@@ -72,6 +77,7 @@ jobs:
           IMAGE_TAG: ${{ inputs.image-tag }}
           TARGET: ${{ inputs.image-target }}
           CACHE_BUILDX_YARN: ${{ inputs.cache-buildx-yarn }}
+          PUBLISH: ${{ inputs.publish }}
         run: |
           timestamp=$(date +%s)
           sha=$(git rev-parse --short HEAD)
@@ -86,6 +92,10 @@ jobs:
             cache_args="--cache-to type=local,dest=/tmp/$IMAGE_TAG-buildx-cache --cache-from type=local,src=/tmp/$IMAGE_TAG-buildx-cache"
           fi
 
-          # build, tag, push
+          # build, tag
           docker build --secret id=npm-token,env=NPM_TOKEN . -t $tag --target "$TARGET" $cache_args
-          docker push $tag
+
+          # push if publish is true
+          if [ "$PUBLISH" = "true" ]; then
+            docker push $tag
+          fi

--- a/.github/workflows/docker-build-tag-publish.yml
+++ b/.github/workflows/docker-build-tag-publish.yml
@@ -97,7 +97,7 @@ jobs:
           echo "Publish is set to: $PUBLISH"
           echo "\n\n"
           # build, tag
-          docker buildx build --secret id=npm-token,env=NPM_TOKEN -t $tag --target "$TARGET" $cache_args .
+          docker buildx build --secret id=npm-token,env=NPM_TOKEN -t $tag --target "$TARGET" $cache_args --load .
 
           # push if publish is true
           if [ "$PUBLISH" = "true" ]; then


### PR DESCRIPTION
# overview

The Docker build process has been updated to support Buildx caching and publishing images based on a flag. A new input `cache-buildx-yarn` allows for caching of `.yarn/cache` directory to speed up builds, which requires the mount type set in the Dockerfile. The workflow now also accepts a `publish` input, enabling or disabling the push of the built image after build completion. Various updates have been made to accommodate these changes, including modifications to the GitHub Actions workflow file and the Docker build command.

## testing
ran this on the `encompass-webhook-v2` project i am switching over to use `yarn workspaces`

## tickets
none